### PR TITLE
Use CAP_ANY to auto detect webcam backend

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,12 @@ if __name__ == "__main__":
     webcam_manager = WebcamManager()
 
     # Turn on the webcam
-    cap = cv2.VideoCapture(0, cv2.CAP_DSHOW)
+    cap = cv2.VideoCapture(0, cv2.CAP_ANY)
+
+    if not cap.isOpened():
+        print("ERROR! Unable to open camera")
+        exit
+
     # Set up the Mediapipe environment
     with mediapipe.solutions.holistic.Holistic(
         min_detection_confidence=0.5, min_tracking_confidence=0.5


### PR DESCRIPTION
cv2.CAP_DSHOW is only supported on Windows I believe. With this change it should work autodetect backend and work more cross-platform. Also adds an error condition check so users will get a clue something is wrong instead of abruptly exiting. 